### PR TITLE
Fix update password without bcrypt

### DIFF
--- a/src/Litepie/User/Http/Controllers/UserAdminWebController.php
+++ b/src/Litepie/User/Http/Controllers/UserAdminWebController.php
@@ -170,6 +170,7 @@ class UserAdminWebController extends AdminController
         try {
 
             $attributes = $request->all();
+            $attributes['password'] = bcrypt($attributes['password']);
 
             $user->update($attributes);
             $user->syncRoles($request->get('roles'));


### PR DESCRIPTION
I found that when update user profile, no encrypted function used on password. That will cause unexpected error after updated user profile.

This PR fix this problem 😄 
