### PR TITLE
hotfix/htv_31_1_2020_remove_param_dont_use

### DIFF
--- a/src/Litepie/Menu/Http/Controllers/SubMenuResourceController.php
+++ b/src/Litepie/Menu/Http/Controllers/SubMenuResourceController.php
@@ -29,7 +29,7 @@ class SubMenuResourceController extends ResourceController
         $menu = $this->repository->find($id);
         Form::populate($menu);
 
-        return view('menu::sub.show', compact('parent', 'menu'));
+        return view('menu::sub.show', compact('menu'));
     }
 
     /**


### PR DESCRIPTION
'parent' don't use will make error in php 7.3 and later.  
parent does not exits.