### PR TITLE
changed settings call- php7.3 compatibility issues

### DIFF
--- a/src/Litepie/Settings/Http/Controllers/SettingResourceController.php
+++ b/src/Litepie/Settings/Http/Controllers/SettingResourceController.php
@@ -129,5 +129,4 @@ class SettingResourceController extends BaseController
     {
         return $this->repository->setValue($key, $value);
     }
-
 }

--- a/src/Litepie/Settings/Http/Controllers/SettingResourceController.php
+++ b/src/Litepie/Settings/Http/Controllers/SettingResourceController.php
@@ -65,7 +65,6 @@ class SettingResourceController extends BaseController
             $attributes = $request->all();
 
             if (user()->hasRole('superuser')) {
-
                 if (isset($attributes['settings']) && is_array($attributes['settings'])) {
                     foreach ($attributes['settings'] as $key => $value) {
                         $this->repository->setValue($key, $value);
@@ -103,7 +102,6 @@ class SettingResourceController extends BaseController
                 ->url(guard_url("/settings/$type"))
                 ->redirect();
         }
-
     }
 
     /**

--- a/src/Litepie/Settings/Http/Controllers/SettingResourceController.php
+++ b/src/Litepie/Settings/Http/Controllers/SettingResourceController.php
@@ -49,7 +49,7 @@ class SettingResourceController extends BaseController
      */
     public function show($slug)
     {
-        return view('settings::partial.' . $slug);
+        return view('settings::partial.'.$slug);
     }
 
     /**

--- a/src/Litepie/Settings/Http/Controllers/SettingResourceController.php
+++ b/src/Litepie/Settings/Http/Controllers/SettingResourceController.php
@@ -36,7 +36,7 @@ class SettingResourceController extends BaseController
     {
         return $this->response->setMetaTitle(trans('settings::setting.names'))
             ->view('settings::index')
-            ->data(compact('settings'))
+            ->data(Setting::all())
             ->output();
     }
 


### PR DESCRIPTION
Problem:
For fresh installations lavalite admin settings can't be called due to compatibility issues with compact and php7.3.
https://github.com/LavaLite/cms/issues/307

Solution:
Either a settings variable should be declared or the settings should be called directly until the Laravel version is updated

compact with undefined variable breaks on PHP 7.3:
https://github.com/laravel/framework/issues/26936