### PR TITLE
Fix "compact(): Undefined variable: settings"

### DIFF
--- a/src/Litepie/Settings/Http/Controllers/SettingResourceController.php
+++ b/src/Litepie/Settings/Http/Controllers/SettingResourceController.php
@@ -49,7 +49,7 @@ class SettingResourceController extends BaseController
      */
     public function show($slug)
     {
-        return view('settings::partial.' . $slug);
+        return view('settings::partial.'.$slug);
     }
 
     /**
@@ -65,7 +65,6 @@ class SettingResourceController extends BaseController
             $attributes = $request->all();
 
             if (user()->hasRole('superuser')) {
-
                 if (isset($attributes['settings']) && is_array($attributes['settings'])) {
                     foreach ($attributes['settings'] as $key => $value) {
                         $this->repository->setValue($key, $value);
@@ -103,7 +102,6 @@ class SettingResourceController extends BaseController
                 ->url(guard_url("/settings/$type"))
                 ->redirect();
         }
-
     }
 
     /**
@@ -131,5 +129,4 @@ class SettingResourceController extends BaseController
     {
         return $this->repository->setValue($key, $value);
     }
-
 }

--- a/src/Litepie/Settings/Http/Controllers/SettingResourceController.php
+++ b/src/Litepie/Settings/Http/Controllers/SettingResourceController.php
@@ -34,7 +34,7 @@ class SettingResourceController extends BaseController
      */
     public function index(SettingRequest $request)
     {
-        return $this->response->setMetaTitle(trans('settings::setting.names'))
+        return $this->response->setMetaTitle($settings = trans('settings::setting.names'))
             ->view('settings::index')
             ->data(compact('settings'))
             ->output();


### PR DESCRIPTION
Define variable `$settings` from translated names, used in `compact('settings')`.