### PR TITLE
Production checking changed from config('app.key') to config('app.env')

### DIFF
--- a/src/Litepie/Install/Installers/Scripts/ProtectInstaller.php
+++ b/src/Litepie/Install/Installers/Scripts/ProtectInstaller.php
@@ -4,24 +4,10 @@ namespace Litepie\Install\Installers\Scripts;
 
 use Exception;
 use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
 use Litepie\Install\Installers\SetupScript;
 
 class ProtectInstaller implements SetupScript
 {
-    /**
-     * @var Filesystem
-     */
-    protected $finder;
-
-    /**
-     * @param Filesystem $finder
-     */
-    public function __construct(Filesystem $finder)
-    {
-        $this->finder = $finder;
-    }
-
     /**
      * Fire the install script.
      *
@@ -33,9 +19,7 @@ class ProtectInstaller implements SetupScript
      */
     public function fire(Command $command)
     {
-        $currentKey = config('app.key');
-
-        if (strlen($currentKey) !== 0) {
+        if (config('app.env')=='production') {
             $command->alert('Application In Production!');
 
             if (!$command->confirm('Do you really wish to continue the installation?')) {


### PR DESCRIPTION
I think this is better to check with APP_ENV instead of APP_KEY because in local as well this is going to show application is in production
let me know your throughts on this

and Filesystem $finder and constructor is also not needed let me know what do you say about that
Thanks